### PR TITLE
simplify info types

### DIFF
--- a/src/file.zig
+++ b/src/file.zig
@@ -21,7 +21,7 @@ extern var file_pathsep: [*c]u8;
 extern var patterns: [*c][*c]u8;
 extern var ipatterns: [*c][*c]u8;
 
-extern fn free_dir(d: [*c][*c]types.Info) void;
+extern fn free_dir(d: [*c]?*types.Info) void;
 
 const MAXPATH = 64 * 1024; // 64KB paths maximum
 
@@ -122,8 +122,8 @@ fn fprune(
     path: [*c]const u8,
     matched_in: bool,
     root: bool,
-) [*c][*c]types.Info {
-    var dir: [*c][*c]types.Info = null;
+) [*c]?*types.Info {
+    var dir: [*c]?*types.Info = null;
     var new_head: [*c]types.Info = null;
     var end: [*c]types.Info = null;
     var count: usize = 0;
@@ -218,13 +218,13 @@ fn fprune(
         if (flag.condense_singletons) {
             while (util.is_singleton(@ptrCast(ent))) {
                 const child = ent[0].child;
-                var segs = [_][*c]const u8{ ent[0].name, child[0][0].name };
+                var segs = [_][*c]const u8{ ent[0].name, child[0].?.name };
                 const name = util.pathconcat(@ptrCast(&segs), 2);
                 std.c.free(ent[0].name);
                 ent[0].name = util.scopy(name);
-                ent[0].child = child[0][0].child;
-                ent[0].condensed = ent[0].condensed + 1 + child[0][0].condensed;
-                free_dir(@ptrCast(child));
+                ent[0].child = child[0].?.child;
+                ent[0].condensed = ent[0].condensed + 1 + child[0].?.condensed;
+                free_dir(child);
             }
         }
 
@@ -253,7 +253,7 @@ fn fprune(
     if (end != null) end[0].next = null;
 
     if (count > 0) {
-        const arr: [*c][*c]types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf([*c]types.Info) * (count + 1))));
+        const arr: [*c]?*types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf(?*types.Info) * (count + 1))));
         var i: usize = 0;
         var e: [*c]types.Info = new_head;
         while (e != null) : (i += 1) {
@@ -263,7 +263,7 @@ fn fprune(
         arr[count] = null;
 
         if (list.topsort != null and count > 1) {
-            std.mem.sort([*c]types.Info, arr[0..count], list.topsort.?, list.infoLessThan);
+            std.mem.sort(?*types.Info, arr[0..count], list.topsort.?, list.infoLessThan);
         }
         dir = arr;
     }
@@ -280,7 +280,7 @@ pub fn file_getfulltree(
     dev: c.dev_t,
     size: *c.off_t,
     err: [*c][*c]u8,
-) [*c][*c]types.Info {
+) [*c]?*types.Info {
     _ = lev;
     _ = dev;
     _ = err;
@@ -362,7 +362,7 @@ pub fn tabedfile_getfulltree(
     dev: c.dev_t,
     size: *c.off_t,
     err: [*c][*c]u8,
-) [*c][*c]types.Info {
+) [*c]?*types.Info {
     _ = lev;
     _ = dev;
     _ = err;
@@ -380,9 +380,9 @@ pub fn tabedfile_getfulltree(
     const maxstack: usize = 2048;
     const path: [*c]u8 = @ptrCast(@alignCast(util.xmalloc(MAXPATH)));
     defer std.c.free(path);
-    const istack: [*c][*c]types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf([*c]types.Info) * maxstack)));
+    const istack: [*c]?*types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf(?*types.Info) * maxstack)));
     defer std.c.free(@ptrCast(istack));
-    @memset(@as([*]u8, @ptrCast(istack))[0 .. @sizeOf([*c]types.Info) * maxstack], 0);
+    @memset(@as([*]u8, @ptrCast(istack))[0 .. @sizeOf(?*types.Info) * maxstack], 0);
 
     var line: usize = 0;
     var top: usize = 0;
@@ -422,14 +422,14 @@ pub fn tabedfile_getfulltree(
             continue;
         }
 
-        const dir_ptr: *[*c]types.Info = if (tabs != 0) @ptrCast(&(istack[tabs - 1][0].tchild)) else &root;
+        const dir_ptr: *[*c]types.Info = if (tabs != 0) @ptrCast(&(istack[tabs - 1].?.tchild)) else &root;
         const ent: [*c]types.Info = search(dir_ptr, spath);
         istack[tabs] = ent;
         ent[0].mode = @intCast(std.posix.S.IFREG);
 
         if (tabs > 0) {
-            istack[tabs - 1][0].isdir = true;
-            istack[tabs - 1][0].mode = @intCast(std.posix.S.IFDIR);
+            istack[tabs - 1].?.isdir = true;
+            istack[tabs - 1].?.mode = @intCast(std.posix.S.IFDIR);
         }
 
         if (link != null) {

--- a/src/list.zig
+++ b/src/list.zig
@@ -15,15 +15,15 @@ const filter = @import("filter.zig");
 const info_mod = @import("info.zig");
 const linux = @import("linux.zig");
 
-pub const GetFullTreeFn = fn ([*c]u8, c_ulong, c.dev_t, *c.off_t, [*c][*c]u8) [*c][*c]types.Info;
-pub const SortFn = fn ([*c]types.Info, [*c]types.Info) c_int;
+pub const GetFullTreeFn = fn ([*c]u8, c_ulong, c.dev_t, *c.off_t, [*c][*c]u8) [*c]?*types.Info;
+pub const SortFn = fn (*types.Info, *types.Info) c_int;
 
 pub var getfulltree: *const GetFullTreeFn = undefined;
 pub var basesort: ?*const SortFn = null;
 pub var topsort: ?*const SortFn = null;
 
-pub fn infoLessThan(cmp: *const SortFn, a: [*c]types.Info, b: [*c]types.Info) bool {
-    return cmp(a, b) < 0;
+pub fn infoLessThan(cmp: *const SortFn, a: ?*types.Info, b: ?*types.Info) bool {
+    return cmp(a.?, b.?) < 0;
 }
 
 var lstat_info: types.Info = std.mem.zeroes(types.Info);
@@ -85,8 +85,8 @@ extern var errors: c_int;
 extern var Level: isize;
 extern var htmldirlen: usize;
 
-extern fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c][*c]types.Info;
-extern fn free_dir(d: [*c][*c]types.Info) void;
+extern fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c]?*types.Info;
+extern fn free_dir(d: [*c]?*types.Info) void;
 
 var errbuf: [256]u8 = undefined;
 var realbasepath: [c.PATH_MAX]u8 = std.mem.zeroes([c.PATH_MAX]u8);
@@ -118,7 +118,7 @@ pub fn emit_tree(lc: types.ListingCalls, dirname: [*c][*c]u8, needfulltree: bool
 
     var i: usize = 0;
     while (dirname[i] != null) : (i += 1) {
-        var dir: [*c][*c]types.Info = null;
+        var dir: [*c]?*types.Info = null;
         var info: [*c]types.Info = null;
 
         if (flag.hyper) {
@@ -202,7 +202,7 @@ pub fn emit_tree(lc: types.ListingCalls, dirname: [*c][*c]u8, needfulltree: bool
 pub fn listdir(
     lc: types.ListingCalls,
     dirname: [*c]u8,
-    dir_in: [*c][*c]types.Info,
+    dir_in: [*c]?*types.Info,
     lev: c_int,
     dev: c.dev_t,
     hasfulltree: bool,
@@ -211,7 +211,7 @@ pub fn listdir(
     var subtotal: types.Totals = undefined;
     var ig: ?*types.IgnoreFile = null;
     var inf: ?*types.InfoFile = null;
-    var subdir: [*c][*c]types.Info = null;
+    var subdir: [*c]?*types.Info = null;
     var namemax: usize = 257;
     var htmldescend: c_int = 0;
     var n: isize = undefined;
@@ -228,7 +228,7 @@ pub fn listdir(
     n = 0;
     while (dir_in[@as(usize, @intCast(n))] != null) : (n += 1) {}
     if (topsort != null) {
-        std.mem.sort([*c]types.Info, dir_in[0..@intCast(n)], topsort.?, infoLessThan);
+        std.mem.sort(?*types.Info, dir_in[0..@intCast(n)], topsort.?, infoLessThan);
     }
 
     var cursor = dir_in;
@@ -236,39 +236,38 @@ pub fn listdir(
 
     var path: [*c]u8 = @ptrCast(util.xmalloc(@sizeOf(u8) * pathlen));
 
-    while (cursor[0] != null) : (cursor += 1) {
-        const entry = cursor[0];
+    while (cursor[0]) |entry| : (cursor += 1) {
         _ = lc.printinfo.?(dirname, entry, lev);
 
-        const namelen: usize = c.strlen(entry.*.name) + 1;
+        const namelen: usize = c.strlen(entry.name) + 1;
         if (namemax < namelen) {
             namemax = namelen;
             pathlen = dirlen + namemax;
             path = @ptrCast(util.xrealloc(path, pathlen));
         }
         if (es) {
-            _ = c.sprintf(path, "%s%s", dirname, entry.*.name);
+            _ = c.sprintf(path, "%s%s", dirname, entry.name);
         } else {
-            _ = c.sprintf(path, "%s/%s", dirname, entry.*.name);
+            _ = c.sprintf(path, "%s/%s", dirname, entry.name);
         }
-        const filename: [*c]u8 = if (flag.f) path else entry.*.name;
+        const filename: [*c]u8 = if (flag.f) path else entry.name;
 
         var descend: c_int = 0;
         err = null;
         const newpath: [*c]u8 = path;
 
-        if (entry.*.isdir) {
+        if (entry.isdir) {
             tot.dirs += 1;
-            if (flag.condense_singletons) tot.dirs += entry.*.condensed;
+            if (flag.condense_singletons) tot.dirs += entry.condensed;
 
             var found: bool = false;
             if (!hasfulltree) {
-                found = hash.findino(entry.*.inode, entry.*.dev);
-                if (!found) hash.saveino(entry.*.inode, entry.*.dev);
+                found = hash.findino(entry.inode, entry.dev);
+                if (!found) hash.saveino(entry.inode, entry.dev);
             }
 
-            const xdev_block = flag.xdev and dev != entry.*.dev;
-            const link_block = entry.*.lnk != null and !flag.l;
+            const xdev_block = flag.xdev and dev != entry.dev;
+            const link_block = entry.lnk != null and !flag.l;
             if (!xdev_block and !link_block) {
                 descend = 1;
 
@@ -286,7 +285,7 @@ pub fn listdir(
                 //   }
                 // }
 
-                if (entry.*.lnk != null and found) {
+                if (entry.lnk != null and found) {
                     err = @constCast("recursive, not followed");
                     // Not actually a problem if we weren't going to descend anyway:
                     if (Level >= 0 and lev > Level) err = null;
@@ -326,8 +325,8 @@ pub fn listdir(
 
                 if (descend > 0) {
                     if (hasfulltree) {
-                        subdir = entry.*.child;
-                        err = entry.*.err;
+                        subdir = entry.child;
+                        err = entry.err;
                     } else {
                         filter.pushFiles(newpath, &ig, &inf, false);
                         subdir = read_dir(newpath, &n, @intFromBool(inf != null));

--- a/src/tree.zig
+++ b/src/tree.zig
@@ -362,16 +362,16 @@ export fn indent(w: *std.Io.Writer, maxlevel: c_int) void {
 // ---------------------------------------------------------------------------
 
 // filesfirst and dirsfirst are now top-level meta-sorts.
-fn filesfirst(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    if (a[0].isdir != b[0].isdir) {
-        return if (a[0].isdir) 1 else -1;
+fn filesfirst(a: *types.Info, b: *types.Info) c_int {
+    if (a.isdir != b.isdir) {
+        return if (a.isdir) 1 else -1;
     }
     return list.basesort.?(a, b);
 }
 
-fn dirsfirst(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    if (a[0].isdir != b[0].isdir) {
-        return if (a[0].isdir) -1 else 1;
+fn dirsfirst(a: *types.Info, b: *types.Info) c_int {
+    if (a.isdir != b.isdir) {
+        return if (a.isdir) -1 else 1;
     }
     return list.basesort.?(a, b);
 }
@@ -402,31 +402,31 @@ fn namecoll(a: [*c]u8, b: [*c]u8) c_int {
     return c.strcoll(a, b);
 }
 
-fn alnumsort(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    const v = namecoll(a[0].name, b[0].name);
+fn alnumsort(a: *types.Info, b: *types.Info) c_int {
+    const v = namecoll(a.name, b.name);
     return if (flag.reverse) -v else v;
 }
 
-fn versort(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    const v = strverscmp(a[0].name, b[0].name);
+fn versort(a: *types.Info, b: *types.Info) c_int {
+    const v = strverscmp(a.name, b.name);
     return if (flag.reverse) -v else v;
 }
 
-fn mtimesort(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    if (a[0].mtime == b[0].mtime) {
-        const v = namecoll(a[0].name, b[0].name);
+fn mtimesort(a: *types.Info, b: *types.Info) c_int {
+    if (a.mtime == b.mtime) {
+        const v = namecoll(a.name, b.name);
         return if (flag.reverse) -v else v;
     }
-    const v: c_int = if (a[0].mtime < b[0].mtime) -1 else 1;
+    const v: c_int = if (a.mtime < b.mtime) -1 else 1;
     return if (flag.reverse) -v else v;
 }
 
-fn ctimesort(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    if (a[0].ctime == b[0].ctime) {
-        const v = namecoll(a[0].name, b[0].name);
+fn ctimesort(a: *types.Info, b: *types.Info) c_int {
+    if (a.ctime == b.ctime) {
+        const v = namecoll(a.name, b.name);
         return if (flag.reverse) -v else v;
     }
-    const v: c_int = if (a[0].ctime < b[0].ctime) -1 else 1;
+    const v: c_int = if (a.ctime < b.ctime) -1 else 1;
     return if (flag.reverse) -v else v;
 }
 
@@ -434,9 +434,9 @@ fn sizecmp(a: c.off_t, b: c.off_t) c_int {
     return if (a == b) 0 else if (a < b) 1 else -1;
 }
 
-fn fsizesort(a: [*c]types.Info, b: [*c]types.Info) c_int {
-    var v = sizecmp(@intCast(a[0].size), @intCast(b[0].size));
-    if (v == 0) v = namecoll(a[0].name, b[0].name);
+fn fsizesort(a: *types.Info, b: *types.Info) c_int {
+    var v = sizecmp(@intCast(a.size), @intCast(b.size));
+    if (v == 0) v = namecoll(a.name, b.name);
     return if (flag.reverse) -v else v;
 }
 
@@ -601,25 +601,25 @@ fn getinfo(name: [*c]const u8, path: [*c]u8) ?*types.Info {
     return ent;
 }
 
-export fn free_dir(d: [*c][*c]types.Info) void {
+export fn free_dir(d: [*c]?*types.Info) void {
     var i: usize = 0;
-    while (d[i] != null) : (i += 1) {
-        c.free(d[i].*.name);
-        if (d[i].*.lnk != null) c.free(d[i].*.lnk);
+    while (d[i]) |entry| : (i += 1) {
+        c.free(entry.name);
+        if (entry.lnk != null) c.free(entry.lnk);
         if (comptime builtin.os.tag == .linux) {
-            if (d[i].*.secontext != null) c.free(d[i].*.secontext);
+            if (entry.secontext != null) c.free(entry.secontext);
         }
-        if (d[i].*.comment != null) {
+        if (entry.comment != null) {
             var j: usize = 0;
-            while (d[i].*.comment[j] != null) : (j += 1) c.free(d[i].*.comment[j]);
+            while (entry.comment[j] != null) : (j += 1) c.free(entry.comment[j]);
         }
-        if (d[i].*.err != null) c.free(d[i].*.err);
-        c.free(@ptrCast(d[i]));
+        if (entry.err != null) c.free(entry.err);
+        c.free(@ptrCast(entry));
     }
     c.free(@ptrCast(d));
 }
 
-export fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c][*c]types.Info {
+export fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c]?*types.Info {
     if (read_dir_path == null) {
         read_dir_pathsize = c.strlen(dir) + c.PATH_MAX;
         read_dir_path = @ptrCast(util.xmalloc(read_dir_pathsize));
@@ -631,7 +631,7 @@ export fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c][*c]types.Info
     if (d == null) return null;
 
     var ne: usize = c.MINIT;
-    var dl: [*c][*c]types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf([*c]types.Info) * ne)));
+    var dl: [*c]?*types.Info = @ptrCast(@alignCast(util.xmalloc(@sizeOf(?*types.Info) * ne)));
     var p: usize = 0;
 
     while (true) {
@@ -669,7 +669,7 @@ export fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c][*c]types.Info
                 inf.comment[cnt] = null;
             }
             if (p == (ne - 1)) {
-                dl = @ptrCast(@alignCast(util.xrealloc(@ptrCast(dl), @sizeOf([*c]types.Info) * (ne + c.MINC))));
+                dl = @ptrCast(@alignCast(util.xrealloc(@ptrCast(dl), @sizeOf(?*types.Info) * (ne + c.MINC))));
                 ne += c.MINC;
             }
             dl[p] = inf;
@@ -691,14 +691,14 @@ export fn read_dir(dir: [*c]u8, n: [*c]isize, infotop: c_int) [*c][*c]types.Info
 // This is for all the impossible things people wanted the old tree to do.
 // This can and will use a large amount of memory for large directory trees
 // and also take some time.
-fn unix_getfulltree(d: [*c]u8, lev: c_ulong, dev_in: c.dev_t, size: *c.off_t, err: [*c][*c]u8) [*c][*c]types.Info {
+fn unix_getfulltree(d: [*c]u8, lev: c_ulong, dev_in: c.dev_t, size: *c.off_t, err: [*c][*c]u8) [*c]?*types.Info {
     var dev: c.dev_t = dev_in;
     var path: [*c]u8 = undefined;
     var pathsize: usize = 0;
     var ig: ?*types.IgnoreFile = null;
     var inf: ?*types.InfoFile = null;
-    var sav: [*c][*c]types.Info = undefined;
-    var dir_ptr: [*c][*c]types.Info = undefined;
+    var sav: [*c]?*types.Info = undefined;
+    var dir_ptr: [*c]?*types.Info = undefined;
     var n: isize = undefined;
     var tmp_pattern: c_int = 0;
 
@@ -754,78 +754,77 @@ fn unix_getfulltree(d: [*c]u8, lev: c_ulong, dev_in: c.dev_t, size: *c.off_t, er
         maxdirs += 1024;
     }
 
-    while (dir_ptr.* != null) {
-        const entry = dir_ptr.*;
-        if (entry.*.isdir and !(flag.xdev and dev != @as(c.dev_t, @intCast(entry.*.dev)))) {
-            if (entry.*.lnk != null) {
+    while (dir_ptr.*) |entry| {
+        if (entry.isdir and !(flag.xdev and dev != @as(c.dev_t, @intCast(entry.dev)))) {
+            if (entry.lnk != null) {
                 if (flag.l) {
-                    if (hash.findino(@intCast(entry.*.inode), @intCast(entry.*.dev))) {
-                        entry.*.err = util.scopy("recursive, not followed");
+                    if (hash.findino(@intCast(entry.inode), @intCast(entry.dev))) {
+                        entry.err = util.scopy("recursive, not followed");
                     } else {
-                        hash.saveino(@intCast(entry.*.inode), @intCast(entry.*.dev));
-                        if (entry.*.lnk[0] == '/') {
-                            entry.*.child = unix_getfulltree(entry.*.lnk, lev + 1, dev, @ptrCast(&entry.*.size), &(entry.*.err));
+                        hash.saveino(@intCast(entry.inode), @intCast(entry.dev));
+                        if (entry.lnk[0] == '/') {
+                            entry.child = unix_getfulltree(entry.lnk, lev + 1, dev, @ptrCast(&entry.size), &(entry.err));
                         } else {
                             const dlen = c.strlen(d);
-                            const llen = c.strlen(entry.*.lnk);
+                            const llen = c.strlen(entry.lnk);
                             if (dlen + llen + 2 > pathsize) {
                                 pathsize = dlen + llen + 1024;
                                 path = @ptrCast(util.xrealloc(path, pathsize));
                             }
                             if (flag.f and c.strcmp(d, "/") == 0) {
-                                _ = c.sprintf(path, "%s%s", d, entry.*.lnk);
+                                _ = c.sprintf(path, "%s%s", d, entry.lnk);
                             } else {
-                                _ = c.sprintf(path, "%s/%s", d, entry.*.lnk);
+                                _ = c.sprintf(path, "%s/%s", d, entry.lnk);
                             }
-                            entry.*.child = unix_getfulltree(path, lev + 1, dev, @ptrCast(&entry.*.size), &(entry.*.err));
+                            entry.child = unix_getfulltree(path, lev + 1, dev, @ptrCast(&entry.size), &(entry.err));
                         }
                     }
                 }
             } else {
                 const dlen = c.strlen(d);
-                const nlen = c.strlen(entry.*.name);
+                const nlen = c.strlen(entry.name);
                 if (dlen + nlen + 2 > pathsize) {
                     pathsize = dlen + nlen + 1024;
                     path = @ptrCast(util.xrealloc(path, pathsize));
                 }
 
                 if (flag.f and c.strcmp(d, "/") == 0) {
-                    _ = c.sprintf(path, "%s%s", d, entry.*.name);
+                    _ = c.sprintf(path, "%s%s", d, entry.name);
                 } else {
-                    _ = c.sprintf(path, "%s/%s", d, entry.*.name);
+                    _ = c.sprintf(path, "%s/%s", d, entry.name);
                 }
 
-                hash.saveino(@intCast(entry.*.inode), @intCast(entry.*.dev));
-                entry.*.child = unix_getfulltree(path, lev + 1, dev, @ptrCast(&entry.*.size), &(entry.*.err));
+                hash.saveino(@intCast(entry.inode), @intCast(entry.dev));
+                entry.child = unix_getfulltree(path, lev + 1, dev, @ptrCast(&entry.size), &(entry.err));
 
                 if (flag.condense_singletons) {
-                    while (util.is_singleton(@ptrCast(entry))) {
-                        const child = entry.*.child;
-                        var segs = [_][*c]u8{ entry.*.name, child[0].*.name };
+                    while (util.is_singleton(entry)) {
+                        const child = entry.child;
+                        var segs = [_][*c]u8{ entry.name, child[0].?.name };
                         const new_name = util.pathconcat(@ptrCast(&segs), 2);
-                        c.free(entry.*.name);
-                        entry.*.name = util.scopy(new_name);
-                        entry.*.child = child[0].*.child;
-                        entry.*.condensed = entry.*.condensed + 1 + child[0].*.condensed;
+                        c.free(entry.name);
+                        entry.name = util.scopy(new_name);
+                        entry.child = child[0].?.child;
+                        entry.condensed = entry.condensed + 1 + child[0].?.condensed;
                         free_dir(child);
                     }
                 }
             }
             // prune empty folders, unless they match the requested pattern
-            if (flag.prune and entry.*.child == null and
-                !(flag.matchdirs and pattern != 0 and pat.include(entry.*.name, patterns[0..@intCast(pattern)], entry.*.isdir, false, flag.ignorecase, file_pathsep[0]) != 0))
+            if (flag.prune and entry.child == null and
+                !(flag.matchdirs and pattern != 0 and pat.include(entry.name, patterns[0..@intCast(pattern)], entry.isdir, false, flag.ignorecase, file_pathsep[0]) != 0))
             {
                 const xp = entry;
-                var p: [*c][*c]types.Info = dir_ptr;
+                var p: [*c]?*types.Info = dir_ptr;
                 while (p.* != null) : (p += 1) p.* = (p + 1).*;
                 n -= 1;
-                c.free(xp.*.name);
-                if (xp.*.lnk != null) c.free(xp.*.lnk);
+                c.free(xp.name);
+                if (xp.lnk != null) c.free(xp.lnk);
                 c.free(@ptrCast(xp));
                 continue;
             }
         }
-        if (flag.du) size.* += @intCast(entry.*.size);
+        if (flag.du) size.* += @intCast(entry.size);
         dir_ptr += 1;
     }
 
@@ -836,7 +835,7 @@ fn unix_getfulltree(d: [*c]u8, lev: c_ulong, dev_in: c.dev_t, size: *c.off_t, er
 
     // sorting needs to be deferred for --du:
     if (list.topsort != null) {
-        std.mem.sort([*c]types.Info, sav[0..@intCast(n)], list.topsort.?, list.infoLessThan);
+        std.mem.sort(?*types.Info, sav[0..@intCast(n)], list.topsort.?, list.infoLessThan);
     }
 
     c.free(path);

--- a/src/types.zig
+++ b/src/types.zig
@@ -81,7 +81,7 @@ const InfoLinux = extern struct {
     tag: [*c]const u8,
     condensed: usize,
     comment: [*c][*c]u8,
-    child: [*c][*c]InfoLinux,
+    child: [*c]?*InfoLinux,
     next: ?*InfoLinux,
     tchild: ?*InfoLinux,
 };
@@ -110,7 +110,7 @@ const InfoOther = extern struct {
     tag: [*c]const u8,
     condensed: usize,
     comment: [*c][*c]u8,
-    child: [*c][*c]InfoOther,
+    child: [*c]?*InfoOther,
     next: ?*InfoOther,
     tchild: ?*InfoOther,
 };

--- a/src/util.zig
+++ b/src/util.zig
@@ -83,7 +83,7 @@ pub fn is_singleton(dir: *types.Info) bool {
     if (child == null) return false;
     if (child[0] == null) return false;
     if (child[1] != null) return false;
-    return child[0][0].isdir;
+    return child[0].?.isdir;
 }
 
 pub fn xmalloc(size: usize) *anyopaque {


### PR DESCRIPTION
turn `[*c][*c]types.Info` into `[*c]?*types.Info` to reduce annoying C waste