### PR TITLE
allocator refactor 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build (debug)
 zig build
 
+# Build on Arch Linux (force LLVM + LLD to avoid new glibc system linker relocation issues)
+zig build -Duse-llvm=true -Duse-lld=true
+
+# Recommended for all Linux distros
+zig build -Dtarget=x86_64-linux-musl
+
 # Build with optimization
 zig build -Doptimize=ReleaseFast
 

--- a/build.zig
+++ b/build.zig
@@ -3,15 +3,17 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const use_llvm = b.option(bool, "use-llvm", "Use LLVM as the codegen backend");
+    const use_lld = b.option(bool, "use-lld", "Use LLD as the linker");
 
-    const exe = createExecutable(b, target, optimize);
+    const exe = createExecutable(b, target, optimize, use_llvm, use_lld);
     b.installArtifact(exe);
 
     makeRunStep(b, exe);
     makeTestStep(b, target, optimize);
 }
 
-fn createExecutable(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) *std.Build.Step.Compile {
+fn createExecutable(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, use_llvm: ?bool, use_lld: ?bool) *std.Build.Step.Compile {
     const exe = b.addExecutable(.{
         .name = "bo",
         .root_module = b.createModule(.{
@@ -21,6 +23,8 @@ fn createExecutable(b: *std.Build, target: std.Build.ResolvedTarget, optimize: s
         }),
     });
 
+    exe.use_llvm = use_llvm;
+    exe.use_lld = use_lld;
     exe.root_module.linkSystemLibrary("c", .{});
 
     return exe;

--- a/src/cstd.zig
+++ b/src/cstd.zig
@@ -103,10 +103,7 @@ pub const INFO_PATH: [*:0]const u8 = "/usr/share/finfo/global_info";
 
 const tm = opaque {};
 
-pub extern "c" fn malloc(size: usize) ?*anyopaque;
-pub extern "c" fn realloc(ptr: ?*anyopaque, size: usize) ?*anyopaque;
 pub extern "c" fn free(ptr: ?*anyopaque) void;
-pub extern "c" fn memcpy(noalias dest: ?*anyopaque, noalias src: ?*const anyopaque, n: usize) ?*anyopaque;
 
 // locale-aware string comparison (LC_COLLATE); no zig std equivalent, libc only
 pub extern "c" fn strcoll(s1: [*c]const u8, s2: [*c]const u8) c_int;

--- a/src/list.zig
+++ b/src/list.zig
@@ -98,7 +98,7 @@ export fn emit_hyperlink_path(w: *std.Io.Writer, dirname: [*c]u8) void {
 //  analysis of the different outputs is required.  This all is not as clean as I
 //  had hoped it to be.
 
-pub fn emit_tree(lc: types.ListingCalls, dirname: [*c][*c]u8, needfulltree: bool) void {
+pub fn emit_tree(lc: types.ListingCalls, dirname: [*c][*c]u8, needfulltree: bool) std.mem.Allocator.Error!void {
     var tot = types.Totals{ .files = 0, .dirs = 0, .size = 0 };
     var ig: ?*types.IgnoreFile = null;
     var inf: ?*types.InfoFile = null;
@@ -164,7 +164,7 @@ pub fn emit_tree(lc: types.ListingCalls, dirname: [*c][*c]u8, needfulltree: bool
         } else {
             lc.newline.?(info, 0, 0, 0);
             if (dir != null) {
-                subtotal = listdir(lc, dirname[i], dir, 1, st_dev, needfulltree);
+                subtotal = try listdir(lc, dirname[i], dir, 1, st_dev, needfulltree);
                 subtotal.dirs += 1;
             }
         }
@@ -196,7 +196,7 @@ pub fn listdir(
     lev: c_int,
     dev: c.dev_t,
     hasfulltree: bool,
-) types.Totals {
+) std.mem.Allocator.Error!types.Totals {
     var tot = types.Totals{ .files = 0, .dirs = 0, .size = 0 };
     var subtotal: types.Totals = undefined;
     var ig: ?*types.IgnoreFile = null;
@@ -224,7 +224,8 @@ pub fn listdir(
     var cursor = dir_in;
     dirs[@intCast(lev)] = if (cursor[1] != null) 1 else 2;
 
-    var path: [*c]u8 = @ptrCast(util.xmalloc(@sizeOf(u8) * pathlen));
+    var path: []u8 = try util.gpa.alloc(u8, pathlen);
+    defer util.gpa.free(path);
 
     while (cursor[0]) |entry| : (cursor += 1) {
         _ = lc.printinfo.?(dirname, entry, lev);
@@ -233,18 +234,18 @@ pub fn listdir(
         if (namemax < namelen) {
             namemax = namelen;
             pathlen = dirlen + namemax;
-            path = @ptrCast(util.xrealloc(path, pathlen));
+            path = try util.gpa.realloc(path, pathlen);
         }
         if (es) {
-            _ = c.sprintf(path, "%s%s", dirname, entry.name);
+            _ = c.sprintf(path.ptr, "%s%s", dirname, entry.name);
         } else {
-            _ = c.sprintf(path, "%s/%s", dirname, entry.name);
+            _ = c.sprintf(path.ptr, "%s/%s", dirname, entry.name);
         }
-        const filename: [*c]u8 = if (flag.f) path else entry.name;
+        const filename: [*c]u8 = if (flag.f) path.ptr else entry.name;
 
         var descend: c_int = 0;
         err = null;
-        const newpath: [*c]u8 = path;
+        const newpath: [*c]u8 = path.ptr;
 
         if (entry.isdir) {
             tot.dirs += 1;
@@ -286,26 +287,26 @@ pub fn listdir(
                     if (flag.R) {
                         const outsave = util.file;
                         var paths = [_][*c]u8{ newpath, null };
-                        const output: [*c]u8 = @ptrCast(util.xmalloc(c.strLen(newpath) + 13));
-                        const dirsave: [*c]c_int = @ptrCast(@alignCast(util.xmalloc(@sizeOf(c_int) * @as(usize, @intCast(lev + 2)))));
+                        const output: []u8 = try util.gpa.alloc(u8, c.strLen(newpath) + 13);
+                        defer util.gpa.free(output);
+                        const dirsave: []c_int = try util.gpa.alloc(c_int, @as(usize, @intCast(lev + 2)));
+                        defer util.gpa.free(dirsave);
 
-                        const copy_bytes: usize = @sizeOf(c_int) * @as(usize, @intCast(lev + 1));
-                        _ = c.memcpy(dirsave, dirs, copy_bytes);
-                        _ = c.sprintf(output, "%s/00Tree.html", newpath);
-                        const output_name = std.mem.span(@as([*:0]const u8, @ptrCast(output)));
+                        const copy_len: usize = @intCast(lev + 1);
+                        @memcpy(dirsave[0..copy_len], dirs[0..copy_len]);
+                        _ = c.sprintf(output.ptr, "%s/00Tree.html", newpath);
+                        const output_name = std.mem.span(@as([*:0]const u8, @ptrCast(output.ptr)));
                         util.file = std.Io.Dir.cwd().createFile(util.io, output_name, .{}) catch {
                             std.debug.print("tree: invalid filename '{s}'\n", .{output_name});
                             c.exit(c.EXIT_FAILURE);
                             unreachable;
                         };
-                        emit_tree(lc, &paths, hasfulltree);
+                        try emit_tree(lc, &paths, hasfulltree);
 
-                        c.free(output);
                         util.file.close(util.io);
                         util.file = outsave;
 
-                        _ = c.memcpy(dirs, dirsave, copy_bytes);
-                        c.free(dirsave);
+                        @memcpy(dirs[0..copy_len], dirsave[0..copy_len]);
                         htmldescend = 10;
                     } else {
                         htmldescend = 0;
@@ -346,7 +347,7 @@ pub fn listdir(
         if (descend > 0) {
             lc.newline.?(entry, lev, 0, 0);
 
-            subtotal = listdir(lc, newpath, subdir, lev + 1, dev, hasfulltree);
+            subtotal = try listdir(lc, newpath, subdir, lev + 1, dev, hasfulltree);
             tot.dirs += subtotal.dirs;
             tot.files += subtotal.files;
         } else if (needsclosed == 0) {
@@ -369,6 +370,5 @@ pub fn listdir(
     }
 
     dirs[@intCast(lev)] = 0;
-    c.free(path);
     return tot;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,7 +12,6 @@ pub fn printStdout(io: std.Io, content: []const u8) !void {
 }
 
 pub fn main(init: std.process.Init) !void {
-    const allocator = init.gpa;
     const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     if (args.len == 2 and (std.mem.eql(u8, args[1], "man") or std.mem.eql(u8, args[1], "--man"))) {
@@ -20,5 +19,5 @@ pub fn main(init: std.process.Init) !void {
         return;
     }
 
-    try tree.run(allocator, args, init.io, init.environ_map);
+    try tree.run(init, args);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,7 +13,6 @@ pub fn printStdout(io: std.Io, content: []const u8) !void {
 
 pub fn main(init: std.process.Init) !void {
     const args = try init.minimal.args.toSlice(init.arena.allocator());
-
     if (args.len == 2 and (std.mem.eql(u8, args[1], "man") or std.mem.eql(u8, args[1], "--man"))) {
         try printStdout(init.io, man.content);
         return;

--- a/src/tree.zig
+++ b/src/tree.zig
@@ -862,27 +862,30 @@ pub const RunError = std.mem.Allocator.Error || error{
     TreeHadErrors,
 };
 
-pub fn run(gpa: std.mem.Allocator, args: []const [:0]const u8, io: std.Io, environ: *std.process.Environ.Map) RunError!void {
-    var argv_buf = try gpa.alloc([*c]u8, args.len + 1);
-    defer gpa.free(argv_buf);
+pub fn run(init: std.process.Init, args: []const [:0]const u8) RunError!void {
+    var argv_buf = try init.gpa.alloc([*c]u8, args.len + 1);
+    defer init.gpa.free(argv_buf);
 
     for (args, 0..) |arg, arg_i| {
         argv_buf[arg_i] = @constCast(arg.ptr);
     }
     argv_buf[args.len] = null;
 
-    try runWithArgv(gpa, argv_buf[0..args.len :null], io, environ);
+    try runWithArgv(init, argv_buf[0..args.len :null]);
 }
 
-fn runWithArgv(gpa: std.mem.Allocator, argv_slice: [:null][*c]u8, io: std.Io, environ: *std.process.Environ.Map) RunError!void {
+fn runWithArgv(init: std.process.Init, argv_slice: [:null][*c]u8) RunError!void {
     const argc = argv_slice.len;
     const argv: [*c][*c]u8 = argv_slice.ptr;
 
     list.getfulltree = &unix_getfulltree;
     list.basesort = &alnumsort;
     list.topsort = null;
-    util.init(io, std.Io.File.stdout());
     var dirname: [*c][*c]u8 = null;
+
+    const environ = init.environ_map;
+    util.init(init.io, std.Io.File.stdout(), init.gpa, init.arena.allocator());
+    const gpa = util.gpa;
 
     var patterns_list = try std.ArrayList([*c]u8).initCapacity(gpa, 16);
     var ipatterns_list = try std.ArrayList([*c]u8).initCapacity(gpa, 16);
@@ -1385,7 +1388,7 @@ fn runWithArgv(gpa: std.mem.Allocator, argv_slice: [:null][*c]u8, io: std.Io, en
 
     needfulltree = flag.du or flag.prune or flag.matchdirs or flag.fromfile or flag.condense_singletons;
 
-    emit_tree(lc, dirname, needfulltree);
+    try emit_tree(lc, dirname, needfulltree);
 
     if (outfilename != null) util.file.close(util.io);
 

--- a/src/tree.zig
+++ b/src/tree.zig
@@ -874,6 +874,8 @@ pub fn run(init: std.process.Init, args: []const [:0]const u8) RunError!void {
     try runWithArgv(init, argv_buf[0..args.len :null]);
 }
 
+// FIXME: simplify this by passing args so that we don't do argv_buf allocation and copying at all.
+// additionally, flag parsing should be simpler and flags struct get a better name and other files can stop extern flags access.
 fn runWithArgv(init: std.process.Init, argv_slice: [:null][*c]u8) RunError!void {
     const argc = argv_slice.len;
     const argv: [*c][*c]u8 = argv_slice.ptr;

--- a/src/util.zig
+++ b/src/util.zig
@@ -106,12 +106,17 @@ pub fn scopy(s: [*c]const u8) [*c]u8 {
     return dst;
 }
 
+// Global variables are not ideal but this is temporarily necessary to avoid a giant diff
 pub var io: std.Io = undefined;
 pub var file: std.Io.File = undefined;
+pub var gpa: std.mem.Allocator = undefined;
+pub var arena: std.mem.Allocator = undefined;
 
-pub fn init(new_io: std.Io, new_file: std.Io.File) void {
+pub fn init(new_io: std.Io, new_file: std.Io.File, new_gpa: std.mem.Allocator, new_arena: std.mem.Allocator) void {
     io = new_io;
     file = new_file;
+    gpa = new_gpa;
+    arena = new_arena;
 }
 
 pub fn writer(buffer: []u8) std.Io.File.Writer {


### PR DESCRIPTION
- refactors the allocator to remove externs
- introduces llvm and lld for building in the newest glibc / arch kernel
- removes `c.memcpy` with zig `@memcpy `